### PR TITLE
Fix command for extracting bedrock archive

### DIFF
--- a/src/docs/developers/nodes/mainnet.md
+++ b/src/docs/developers/nodes/mainnet.md
@@ -39,7 +39,7 @@ Use a tool like [aria2](https://aria2.github.io/) to reduce the chance of your d
    ```sh
    mkdir datadir
    cd datadir
-   tar xvf <<PATH_TO_DATA_DIR>>
+   zstd -dc mainnet-bedrock.tar.zst | tar -xvf -
    ```
 
 #### (Optional - OP Mainnet Archive Node) Get the data directory for `l2geth`


### PR DESCRIPTION
The bundled archive file is a `tar` file compressed by `zst`. The Optimism docs don't account for the use of `zstd` which causes a failure on decompression:

```shell
$  tar -xvf mainnet-bedrock.tar.zst  ./
tar: Ignoring unknown extended header keyword 'SCHILY.fflags'
tar: Ignoring unknown extended header keyword 'LIBARCHIVE.xattr.com.apple.FinderInfo'
tar: .: Not found in archive
tar: Exiting with failure status due to previous errors
```

Instead, replace with a one liner that decompresses the `zstd` format, and pipes the results to `tar`. 